### PR TITLE
Fixing includes in some files

### DIFF
--- a/rtl/memory/oc_ram.v
+++ b/rtl/memory/oc_ram.v
@@ -18,13 +18,12 @@
 //
 ////////////////////////////////////////////////////////////////////
 
+`include "../wishbone/package.vh" 
 
 module oc_ram(
 	i_clk,i_rstn,
 	i_m2s_wb,o_s2m_wb
-)
-
-`include "../wishbone/package.vh" ;
+);
 
 input i_clk;
 input i_rstn;

--- a/rtl/memory/oc_rom.v
+++ b/rtl/memory/oc_rom.v
@@ -18,13 +18,12 @@
 //
 ////////////////////////////////////////////////////////////////////
 
+`include "../wishbone/package.vh" 
 
 module oc_rom(
 	i_clk,i_rstn,
 	i_m2s_wb,o_s2m_wb
-)
-
-`include "../wishbone/package.vh" ;
+);
 
 input i_clk;
 input i_rstn;

--- a/rtl/peripherals/gpio/gpio.v
+++ b/rtl/peripherals/gpio/gpio.v
@@ -25,7 +25,7 @@ module gpio(
 	i_gpio,o_gpio
 );
 
-`include "../wishbone/package.vh" ;
+`include "../wishbone/package.vh"
 
 input i_clk;
 input i_rstn;

--- a/rtl/soc/aukv_eggs_soc.v
+++ b/rtl/soc/aukv_eggs_soc.v
@@ -142,7 +142,7 @@ wb_master MASTER0(
 		.i_clk(i_clk),
 		.i_rstn(rsyn0_rstn),
 		.i_en(cache0_code_mem_en),
-		.i_we('b0),
+		.i_we(1'b0),
 		.i_addr(cache0_code_mem_address),
 		.i_data(32'h0),
 		.i_strobe(4'b1111),

--- a/rtl/wishbone/wb_arbiter.v
+++ b/rtl/wishbone/wb_arbiter.v
@@ -23,14 +23,13 @@
 //
 ////////////////////////////////////////////////////////////////////
 
+`include "package.vh"
+
 module wb_arbiter(i_clk,i_rstn,
 	i_m2s0_wb,o_s2m0_wb,
 	i_m2s1_wb,o_s2m1_wb,
 	i_s2m_wb,o_m2s_wb
 );
- 
-
-`include "package.vh" ;
 
 input i_clk;
 input i_rstn;

--- a/tb/soc/aukv_eggs_soc_tb.v
+++ b/tb/soc/aukv_eggs_soc_tb.v
@@ -37,4 +37,4 @@ aukv_eggs_soc DUT0(
 );
 	
 	
-endmodule;
+endmodule


### PR DESCRIPTION
Removing unnecessary ';' characters from some includes and modifying their positions.

These issues were preventing compilation using IVerilog.